### PR TITLE
Implement placeholder components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Welfare M&A Support
+
+This repository contains a sample frontend and backend for a welfare facility M&A support platform.
+
+The `docs/design` and `docs/wireframes` directories are placeholders and currently do not contain documentation.

--- a/frontend/components/buyer/BuyBenefits.jsx
+++ b/frontend/components/buyer/BuyBenefits.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function BuyBenefits() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for BuyBenefits</p>
+    </div>
+  );
+}

--- a/frontend/components/buyer/DemandGraph.jsx
+++ b/frontend/components/buyer/DemandGraph.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function DemandGraph() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for DemandGraph</p>
+    </div>
+  );
+}

--- a/frontend/components/buyer/ROISection.jsx
+++ b/frontend/components/buyer/ROISection.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function ROISection() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for ROISection</p>
+    </div>
+  );
+}

--- a/frontend/components/common/CTAButton.jsx
+++ b/frontend/components/common/CTAButton.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function CTAButton({ label, onClick }) {
+  return (
+    <button
+      className="bg-blue-600 text-white px-4 py-2 rounded"
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}

--- a/frontend/components/common/Footer.jsx
+++ b/frontend/components/common/Footer.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Footer() {
+  return (
+    <footer className="bg-gray-100 p-4 text-center text-sm text-gray-600">
+      <p>&copy; 2025 Welfare M&A Support</p>
+    </footer>
+  );
+}

--- a/frontend/components/common/Navbar.jsx
+++ b/frontend/components/common/Navbar.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Navbar() {
+  return (
+    <nav className="bg-white shadow p-4 flex justify-between">
+      <span className="font-bold text-lg">Welfare M&A</span>
+      <div className="space-x-4">
+        <a className="text-blue-600" href="/">Home</a>
+        <a className="text-blue-600" href="/contact">Contact</a>
+      </div>
+    </nav>
+  );
+}

--- a/frontend/components/contact/ChatBot.jsx
+++ b/frontend/components/contact/ChatBot.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+
+export default function ChatBot() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+
+  const send = () => {
+    if (input.trim()) {
+      setMessages([...messages, { from: 'user', text: input }]);
+      setInput('');
+    }
+  };
+
+  return (
+    <div className="p-4 border rounded">
+      <div className="h-40 overflow-y-auto mb-2 text-sm">
+        {messages.map((m, i) => (
+          <p key={i} className="text-gray-700">{m.text}</p>
+        ))}
+      </div>
+      <input
+        className="border p-2 w-full mb-2"
+        placeholder="Type your message..."
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+      />
+      <button onClick={send} className="bg-blue-600 text-white px-3 py-1 rounded">
+        Send
+      </button>
+    </div>
+  );
+}

--- a/frontend/components/contact/EmailForm.jsx
+++ b/frontend/components/contact/EmailForm.jsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+
+export default function EmailForm() {
+  const [form, setForm] = useState({ name: '', email: '', message: '' });
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const submit = (e) => {
+    e.preventDefault();
+    console.log(form);
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-2">
+      <input
+        name="name"
+        placeholder="Your name"
+        className="border p-2 w-full"
+        value={form.name}
+        onChange={handleChange}
+      />
+      <input
+        name="email"
+        placeholder="Your email"
+        className="border p-2 w-full"
+        value={form.email}
+        onChange={handleChange}
+      />
+      <textarea
+        name="message"
+        placeholder="Your message"
+        className="border p-2 w-full"
+        value={form.message}
+        onChange={handleChange}
+      />
+      <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+        Submit
+      </button>
+    </form>
+  );
+}

--- a/frontend/components/contact/LINEIntegration.jsx
+++ b/frontend/components/contact/LINEIntegration.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function LINEIntegration() {
+  return (
+    <div className="p-4 border rounded text-center">
+      <p className="mb-2 text-gray-700">Add us on LINE for quick support!</p>
+      <a
+        href="https://line.me/R/ti/p/%40example"
+        className="bg-green-500 text-white px-4 py-2 rounded inline-block"
+      >
+        Connect on LINE
+      </a>
+    </div>
+  );
+}

--- a/frontend/components/faq/Categories.jsx
+++ b/frontend/components/faq/Categories.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Categories() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for Categories</p>
+    </div>
+  );
+}

--- a/frontend/components/faq/FAQAccordion.jsx
+++ b/frontend/components/faq/FAQAccordion.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function FAQAccordion() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for FAQAccordion</p>
+    </div>
+  );
+}

--- a/frontend/components/faq/FAQSearch.jsx
+++ b/frontend/components/faq/FAQSearch.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function FAQSearch() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for FAQSearch</p>
+    </div>
+  );
+}

--- a/frontend/components/home/HeroSection.jsx
+++ b/frontend/components/home/HeroSection.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function HeroSection() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for HeroSection</p>
+    </div>
+  );
+}

--- a/frontend/components/home/StrengthsSection.jsx
+++ b/frontend/components/home/StrengthsSection.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function StrengthsSection() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for StrengthsSection</p>
+    </div>
+  );
+}

--- a/frontend/components/legal/PrivacyPolicy.jsx
+++ b/frontend/components/legal/PrivacyPolicy.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function PrivacyPolicy() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for PrivacyPolicy</p>
+    </div>
+  );
+}

--- a/frontend/components/legal/SpecifiedCommercialTransaction.jsx
+++ b/frontend/components/legal/SpecifiedCommercialTransaction.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function SpecifiedCommercialTransaction() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for SpecifiedCommercialTransaction</p>
+    </div>
+  );
+}

--- a/frontend/components/legal/TermsOfService.jsx
+++ b/frontend/components/legal/TermsOfService.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function TermsOfService() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for TermsOfService</p>
+    </div>
+  );
+}

--- a/frontend/components/resources/EbookDownload.jsx
+++ b/frontend/components/resources/EbookDownload.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function EbookDownload() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for EbookDownload</p>
+    </div>
+  );
+}

--- a/frontend/components/resources/LeadForm.jsx
+++ b/frontend/components/resources/LeadForm.jsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+
+export default function LeadForm() {
+  const [form, setForm] = useState({ name: '', email: '' });
+
+  const change = (e) => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const submit = (e) => {
+    e.preventDefault();
+    console.log(form);
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-2">
+      <input
+        name="name"
+        placeholder="Your name"
+        className="border p-2 w-full"
+        value={form.name}
+        onChange={change}
+      />
+      <input
+        name="email"
+        placeholder="Your email"
+        className="border p-2 w-full"
+        value={form.email}
+        onChange={change}
+      />
+      <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+        Download
+      </button>
+    </form>
+  );
+}

--- a/frontend/components/resources/WebinarArchive.jsx
+++ b/frontend/components/resources/WebinarArchive.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function WebinarArchive() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for WebinarArchive</p>
+    </div>
+  );
+}

--- a/frontend/components/seller/QuickAssessmentForm.jsx
+++ b/frontend/components/seller/QuickAssessmentForm.jsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+
+export default function QuickAssessmentForm() {
+  const [form, setForm] = useState({ size: '', revenue: '' });
+
+  const change = (e) => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const submit = (e) => {
+    e.preventDefault();
+    console.log(form);
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-2">
+      <input
+        name="size"
+        placeholder="Facility size"
+        className="border p-2 w-full"
+        value={form.size}
+        onChange={change}
+      />
+      <input
+        name="revenue"
+        placeholder="Annual revenue"
+        className="border p-2 w-full"
+        value={form.revenue}
+        onChange={change}
+      />
+      <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+        Estimate
+      </button>
+    </form>
+  );
+}

--- a/frontend/components/seller/SellBenefits.jsx
+++ b/frontend/components/seller/SellBenefits.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function SellBenefits() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for SellBenefits</p>
+    </div>
+  );
+}

--- a/frontend/components/seller/SellerSuccessStories.jsx
+++ b/frontend/components/seller/SellerSuccessStories.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function SellerSuccessStories() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for SellerSuccessStories</p>
+    </div>
+  );
+}

--- a/frontend/components/serviceOverview/MAProcessDiagram.jsx
+++ b/frontend/components/serviceOverview/MAProcessDiagram.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function MAProcessDiagram() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for MAProcessDiagram</p>
+    </div>
+  );
+}

--- a/frontend/components/serviceOverview/PricingTable.jsx
+++ b/frontend/components/serviceOverview/PricingTable.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function PricingTable() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for PricingTable</p>
+    </div>
+  );
+}

--- a/frontend/components/serviceOverview/StepsExplanation.jsx
+++ b/frontend/components/serviceOverview/StepsExplanation.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function StepsExplanation() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for StepsExplanation</p>
+    </div>
+  );
+}

--- a/frontend/components/successStories/AnonymousCases.jsx
+++ b/frontend/components/successStories/AnonymousCases.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function AnonymousCases() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for AnonymousCases</p>
+    </div>
+  );
+}

--- a/frontend/components/successStories/Interviews.jsx
+++ b/frontend/components/successStories/Interviews.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Interviews() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for Interviews</p>
+    </div>
+  );
+}

--- a/frontend/components/successStories/PublicCases.jsx
+++ b/frontend/components/successStories/PublicCases.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function PublicCases() {
+  return (
+    <div className="p-4">
+      <p className="text-gray-700">TODO: content for PublicCases</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder JSX for all frontend components
- implement simple interactive elements in ChatBot, EmailForm, LeadForm, QuickAssessmentForm
- create minimal Navbar, Footer and CTAButton
- document placeholder docs folders

## Testing
- `npm test --prefix frontend` *(fails: Error: no test specified)*
- `npm test --prefix backend` *(fails: Error: no test specified)*