### PR TITLE
Update menu language and adjust tests

### DIFF
--- a/frontend/__tests__/Navbar.test.jsx
+++ b/frontend/__tests__/Navbar.test.jsx
@@ -1,23 +1,17 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import Navbar from '../components/common/Navbar';
-import PropertyListingPage from '../pages/PropertyListingPage';
-
-test('navbar link navigates to property listing page', async () => {
+// Property Listings のリンクが表示されないことを確認
+test('property listings link is not visible', () => {
   render(
-    <MemoryRouter initialEntries={['/']}>\
+    <MemoryRouter initialEntries={['/']}>
       <Routes>
         <Route path="/" element={<Navbar />} />
-        <Route path="/property-listings" element={<PropertyListingPage />} />
       </Routes>
     </MemoryRouter>
   );
 
-  const link = screen.getByRole('link', { name: '物件一覧' });
-  expect(link).toBeInTheDocument();
-
-  await userEvent.click(link);
-  expect(screen.getByText('物件一覧ページ')).toBeInTheDocument();
+  const link = screen.queryByRole('link', { name: '物件一覧' });
+  expect(link).not.toBeInTheDocument();
 });

--- a/frontend/components/common/Navbar.jsx
+++ b/frontend/components/common/Navbar.jsx
@@ -1,16 +1,16 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
+// メニュー表示内容は日本語に統一
 const menuItems = [
-  { label: 'Home', path: '/' },
-  { label: 'Seller', path: '/seller' },
-  { label: 'Service Overview', path: '/service' },
-  { label: 'Success Stories', path: '/success' },
-  { label: 'Resources', path: '/resources' },
-  { label: 'FAQ', path: '/faq' },
-  { label: 'Contact', path: '/contact' },
-  { label: 'Legal', path: '/legal' },
-  { label: 'Property Listings', path: '/listings' },
+  { label: 'ホーム', path: '/' },
+  { label: '売却をお考えの方', path: '/seller' },
+  { label: 'サービス概要', path: '/service' },
+  { label: '成功事例', path: '/success' },
+  { label: 'お役立ち情報', path: '/resources' },
+  { label: 'よくある質問', path: '/faq' },
+  { label: 'お問い合わせ', path: '/contact' },
+  { label: '法務', path: '/legal' },
 ];
 
 const Navbar = () => {


### PR DESCRIPTION
## Summary
- localize navbar labels to Japanese and remove Property Listings item
- update test to reflect the removal of the listings menu

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd frontend && npm test` *(fails: no test specified)*
- `cd ../backend && npm test` *(fails: no test specified)*