### PR TITLE
Implement JSON option for ChatGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@
 - 画面コンポーネントは `frontend/components` に配置し、ページ単位のコンポーネントは `frontend/pages` に配置します。
 - 開発中は `npm start` でローカルサーバーを立ち上げ、ホットリロードで確認できます。
 
+## OpenAI API の利用
+
+`backend/services/chatGPTService.js` の `createChatCompletion` 関数では、第三引数に
+`true` を渡すことで JSON 形式の応答を要求できます。
+
+```javascript
+const messages = [{ role: 'user', content: 'Tell me a joke.' }];
+const res = await createChatCompletion(messages, false, true);
+```
+
+このオプションでは内部的に `response_format` を指定し、システムプロンプトに JSON で
+回答するよう指示を追加しています。
+
 ## ライセンス
 
 このプロジェクトは MIT ライセンスの下で公開されています。

--- a/backend/services/chatGPTService.js
+++ b/backend/services/chatGPTService.js
@@ -1,11 +1,22 @@
 const openai = require('../utils/openaiClient');
 
-async function createChatCompletion(messages, stream = false) {
-  const response = await openai.createChatCompletion({
+// ChatGPT に問い合わせを行う共通関数
+// stream を true にするとストリームで結果を受け取る
+// asJSON を true にすると JSON 形式での応答を要求する
+async function createChatCompletion(messages, stream = false, asJSON = false) {
+  const params = {
     model: 'gpt-4',
-    messages,
+    messages: asJSON
+      ? [{ role: 'system', content: 'Please reply in JSON format.' }, ...messages]
+      : messages,
     stream,
-  });
+  };
+
+  if (asJSON) {
+    params.response_format = { type: 'json_object' };
+  }
+
+  const response = await openai.createChatCompletion(params);
   return response;
 }
 


### PR DESCRIPTION
## Summary
- support JSON-formatted responses in `createChatCompletion`
- document how to request JSON output via ChatGPT API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b8a8f3d1c8333947371104b7dd8fe